### PR TITLE
Add SetForceTorqueThreshold action for MoveUntilTouch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ find_package(catkin REQUIRED COMPONENTS
 add_action_files(
   DIRECTORY action
   FILES
+    SetForceTorqueThreshold.action
     SetPosition.action
     Trigger.action
 )

--- a/action/SetForceTorqueThreshold.action
+++ b/action/SetForceTorqueThreshold.action
@@ -1,0 +1,7 @@
+float64 force_threshold
+float64 torque_threshold
+---
+bool success
+string message
+---
+# no feedback


### PR DESCRIPTION
Used/implemented in https://github.com/personalrobotics/rewd_controllers/pull/5. This follows the usual convention of returning a failure flag and a text message. No feedback because it is an instantaneous and atomic operation.
