### PR TITLE
Add Action for commanding Joint Mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ add_action_files(
     SetPosition.action
     Trigger.action
     JointGroupCommand.action
+    JointModeCommand.action
 )
 
 generate_messages(DEPENDENCIES

--- a/action/JointModeCommand.action
+++ b/action/JointModeCommand.action
@@ -14,10 +14,10 @@ int32 POSITION       = 0
 int32 VELOCITY       = 1
 int32 EFFORT         = 2
 int32 NOMODE         = 3
+int32 OTHER          = 3
 int32 EMERGENCY_STOP = 4
 int32 SWITCHING      = 5
 int32 ERROR          = 6
-int32 OTHER          = 3
 ---
 
 bool success

--- a/action/JointModeCommand.action
+++ b/action/JointModeCommand.action
@@ -9,11 +9,15 @@ string[] joint_names
 # The order must be identical.
 int32[] modes
 
-int32 EMERGENCY_STOP = -1
-int32 VELOCITY       = 0
-int32 POSITION       = 1
+int32 BEGIN          = -1
+int32 POSITION       = 0
+int32 VELOCITY       = 1
 int32 EFFORT         = 2
-
+int32 NOMODE         = 3
+int32 EMERGENCY_STOP = 4
+int32 SWITCHING      = 5
+int32 ERROR          = 6
+int32 OTHER          = 3
 ---
 
 bool success

--- a/action/JointModeCommand.action
+++ b/action/JointModeCommand.action
@@ -1,0 +1,26 @@
+# Used in time-stamping the goal.
+Header header
+
+# Name list of the joints. You don't need to specify all joints of the
+# robot. Joint names are case-sensitive.
+string[] joint_names
+
+# Mode command to the joints listed in joint_names.
+# The order must be identical.
+int32[] modes
+
+int32 EMERGENCY_STOP = -1
+int32 VELOCITY       = 0
+int32 POSITION       = 1
+int32 EFFORT         = 2
+
+---
+
+bool success
+
+# Human readable description of any error.
+string message
+
+---
+
+# no feedback


### PR DESCRIPTION
Simple action (based off the Trigger Command) that matches the [hardware_interface::JointCommandModes](https://docs.ros.org/en/melodic/api/hardware_interface/html/c++/namespacehardware__interface.html#ae45b83599f0f071f47b9f499bd04a9e8) enum.